### PR TITLE
Fixes up implicit parameter lists

### DIFF
--- a/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
+++ b/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
@@ -27,8 +27,10 @@ class IAMClient @Inject() (
     config: Configuration,
     plugableMetrics: PlugableMetrics,
     ws: WSClient,
-    actorSystem: ActorSystem,
-    implicit val ec: ExecutionContext
+    actorSystem: ActorSystem
+)(
+    implicit
+    val ec: ExecutionContext
 ) extends ((OAuth2Token) => Future[Option[TokenInfo]]) {
 
   val logger: Logger = Logger("security.IAMClient")

--- a/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
@@ -19,8 +19,10 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param ec an ExecutionContext for rules
   */
 class SecurityFilter @Inject() (
-    rulesRepository: SecurityRulesRepository,
-    implicit val mat: Materializer,
+    rulesRepository: SecurityRulesRepository
+)(
+    implicit
+    val mat: Materializer,
     implicit val ec: ExecutionContext
 ) extends Filter {
 

--- a/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
@@ -185,6 +185,6 @@ class IAMClientSpec extends Specification {
       "metrics.name" -> java.util.UUID.randomUUID.toString
     ))
 
-    new IAMClient(clientConfig, new NoOpPlugableMetrics, client, actorSystem, ExecutionContext.Implicits.global)
+    new IAMClient(clientConfig, new NoOpPlugableMetrics, client, actorSystem)(ExecutionContext.Implicits.global)
   }
 }


### PR DESCRIPTION
Zhewbacca didn't curry implicit parameter lists, its often idiomatic to curry implicit lists as thats what allows you to pass in in implicits automatically

Although this makes no difference for dependency injection for the typical way (using Guice), if you need to manually hardwire your `SecurityFilter` it makes it a lot easier since there are fewer parameters that you need to provide (in this case, `ExecutionContext` and `Materializer` can be skipped by marking them as implicit)
