### PR TITLE
Improved error messaging when dealing with scopes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scalariform.formatter.preferences._
 
 val commonSettings = Seq(
   organization := "org.zalando",
-  version := "0.2.1",
+  version := "0.2.1.1",
   scalaVersion := "2.11.8",
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
   publishTo := {
@@ -45,7 +45,7 @@ lazy val playDependencies =
 lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(name := "play-Zhewbacca")
-  .settings(version := "0.2.1")
+  .settings(version := "0.2.1.1")
   .settings(libraryDependencies ++= (testDependencies ++ playDependencies))
   .settings(parallelExecution in Test := false)
 

--- a/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
+++ b/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
@@ -28,8 +28,9 @@ class OAuth2AuthProvider @Inject() (getTokenInfo: (OAuth2Token) => Future[Option
   private def validateTokenInfo(tokenInfo: TokenInfo, token: OAuth2Token, scope: Scope): AuthResult = {
     tokenInfo match {
       case TokenInfo(`token`.value, thatScope, `bearerTokenType`, _) if scope.in(thatScope) => AuthTokenValid(tokenInfo)
-      case _ =>
-        logger.info(s"Token '${token.toSafeString} has insufficient scope or wrong type.'")
+      case TokenInfo(_, thatScope, tokenType, _) =>
+        logger.info(s"Token '${token.toSafeString} has insufficient scope or wrong type, token scopes are ${thatScope.names.mkString(", ")}," +
+          s"token type is $tokenType")
         invalid(token)
     }
   }


### PR DESCRIPTION
Committing this because we are currently trying to debug an application in production that this will be very useful for us.

This shouldn't have any security implications since we are just logging the token type and its scopes as extra info