### PR TITLE
Upgrade to Play Framework 2.6.3 and Scala 2.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   - [Contact](#contact)
   - [License](#license)
   
-Play! (v2.5) library to protect RESTful resource servers using OAuth2. According to [RFC 6749](https://tools.ietf.org/html/rfc6749#section-7):
+Play! (v2.5 - 2.6) library to protect RESTful resource servers using OAuth2. According to [RFC 6749](https://tools.ietf.org/html/rfc6749#section-7):
 
 > The client accesses protected resources by presenting the _access
   token_ to the _resource server_. The resource server MUST _validate_ the

--- a/build.sbt
+++ b/build.sbt
@@ -6,44 +6,47 @@ import scalariform.formatter.preferences._
 val commonSettings = Seq(
   organization := "org.zalando",
   version := "0.2.2",
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.12.3",
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
+    if (isSnapshot.value) {
       Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    }
+    else {
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    }
   },
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
   resolvers := Seq(
-    "scalaz-bintray"    at "http://dl.bintray.com/scalaz/releases",
+    "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
     "scoverage-bintray" at "https://dl.bintray.com/sksamuel/sbt-plugins/"
   )
 )
 
-val playFrameworkVersion = "2.5.9"
+val playFrameworkVersion = "2.6.3"
 
 lazy val testDependencies =
   Seq(
-    "org.specs2" %% "specs2-core" % "3.6.4" % "test",
-    "org.specs2" %% "specs2-junit" % "3.6.4" % "test"
+    "org.specs2" %% "specs2-core" % "3.9.5" % "test",
+    "org.specs2" %% "specs2-junit" % "3.9.5" % "test"
   )
 
 lazy val playDependencies =
   Seq(
-    "com.typesafe.play" %% "play-json"    % playFrameworkVersion,
-    "com.typesafe.play" %% "play-ws"      % playFrameworkVersion,
-    "com.typesafe.play" %% "play"         % playFrameworkVersion,
-    "com.typesafe.play" %% "play-test"    % playFrameworkVersion % "test",
-    "com.typesafe.play" %% "play-specs2"  % playFrameworkVersion % "test"
+    "com.typesafe.play" %% "play-ahc-ws" % playFrameworkVersion,
+    "com.typesafe.play" %% "play-json" % playFrameworkVersion,
+    "com.typesafe.play" %% "play-ws" % playFrameworkVersion,
+    "com.typesafe.play" %% "play" % playFrameworkVersion,
+    "com.typesafe.play" %% "play-test" % playFrameworkVersion % "test",
+    "com.typesafe.play" %% "play-specs2" % playFrameworkVersion % "test"
   )
 
 lazy val libraries =
   Seq(
-    "io.zman" %% "atmos" % "2.1"
+    "io.paradoxical" %% "atmos" % "2.2"
   )
 
 lazy val root = (project in file("."))
@@ -65,14 +68,14 @@ scalastyleFailOnError := true
 // Create a default Scala style task to run with tests
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 
-compileScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toTask("").value
+compileScalastyle := scalastyle.in(Compile).toTask("").value
 
 (compileInputs in(Compile, compile)) <<= (compileInputs in(Compile, compile)) dependsOn compileScalastyle
 
-scalariformSettings
+scalariformSettings(autoformat = true)
 
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
-  .setPreference(DoubleIndentClassDeclaration, true)
+  .setPreference(DoubleIndentConstructorArguments, true)
   .setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
   .setPreference(PreserveSpaceBeforeArguments, false)
   .setPreference(AlignSingleLineCaseStatements, false)

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val commonSettings = Seq(
   )
 )
 
-val playFrameworkVersion = "2.6.3"
+val playFrameworkVersion = "2.6.5"
 
 lazy val testDependencies =
   Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 // style plugins
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
-addSbtPlugin("org.scalastyle"  % "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+addSbtPlugin("org.scalastyle"  % "scalastyle-sbt-plugin" % "1.0.0")
 
 // code coverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
+++ b/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
@@ -43,22 +43,22 @@ class IAMClient @Inject() (
     circuitStatus.get
   }
 
-  val authEndpoint = config.getString("authorisation.iam.endpoint").getOrElse(
+  val authEndpoint = config.getOptional[String]("authorisation.iam.endpoint").getOrElse(
     throw new IllegalArgumentException("Authorisation: IAM endpoint is not configured"))
 
-  val breakerMaxFailures = config.getInt("authorisation.iam.cb.maxFailures").getOrElse(
+  val breakerMaxFailures = config.getOptional[Int]("authorisation.iam.cb.maxFailures").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker max failures is not configured"))
 
-  val breakerCallTimeout = config.getInt("authorisation.iam.cb.callTimeout").getOrElse(
+  val breakerCallTimeout = config.getOptional[Int]("authorisation.iam.cb.callTimeout").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker call timeout is not configured")).millis
 
-  val breakerResetTimeout = config.getInt("authorisation.iam.cb.resetTimeout").getOrElse(
+  val breakerResetTimeout = config.getOptional[Int]("authorisation.iam.cb.resetTimeout").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker reset timeout is not configured")).millis
 
-  val breakerMaxRetries = config.getInt("authorisation.iam.maxRetries").getOrElse(
+  val breakerMaxRetries = config.getOptional[Int]("authorisation.iam.maxRetries").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker max retries is not configured")).attempts
 
-  val breakerRetryBackoff = config.getInt("authorisation.iam.retry.backoff.duration").getOrElse(
+  val breakerRetryBackoff = config.getOptional[Int]("authorisation.iam.retry.backoff.duration").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker the duration of exponential backoff is not configured")).millis
 
   lazy val breaker: CircuitBreaker = new CircuitBreaker(
@@ -83,7 +83,7 @@ class IAMClient @Inject() (
     breaker.withCircuitBreaker(
       plugableMetrics.timing(
         retryAsync(s"Calling $authEndpoint") {
-          ws.url(authEndpoint).withQueryString(("access_token", token.value)).get()
+          ws.url(authEndpoint).withQueryStringParameters(("access_token", token.value)).get()
         })).map { response =>
         response.status match {
           case OK => Some(response.json.as[TokenInfo])

--- a/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
+++ b/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
@@ -31,8 +31,7 @@ class IAMClient @Inject() (
     plugableMetrics: PlugableMetrics,
     ws: WSClient,
     actorSystem: ActorSystem,
-    implicit val ec: ExecutionContext
-) extends ((OAuth2Token) => Future[Option[TokenInfo]]) {
+    implicit val ec: ExecutionContext) extends ((OAuth2Token) => Future[Option[TokenInfo]]) {
 
   val logger: Logger = Logger("security.IAMClient")
 
@@ -45,35 +44,28 @@ class IAMClient @Inject() (
   }
 
   val authEndpoint = config.getString("authorisation.iam.endpoint").getOrElse(
-    throw new IllegalArgumentException("Authorisation: IAM endpoint is not configured")
-  )
+    throw new IllegalArgumentException("Authorisation: IAM endpoint is not configured"))
 
   val breakerMaxFailures = config.getInt("authorisation.iam.cb.maxFailures").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker max failures is not configured")
-  )
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker max failures is not configured"))
 
   val breakerCallTimeout = config.getInt("authorisation.iam.cb.callTimeout").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker call timeout is not configured")
-  ).millis
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker call timeout is not configured")).millis
 
   val breakerResetTimeout = config.getInt("authorisation.iam.cb.resetTimeout").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker reset timeout is not configured")
-  ).millis
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker reset timeout is not configured")).millis
 
   val breakerMaxRetries = config.getInt("authorisation.iam.maxRetries").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker max retries is not configured")
-  ).attempts
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker max retries is not configured")).attempts
 
   val breakerRetryBackoff = config.getInt("authorisation.iam.retry.backoff.duration").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker the duration of exponential backoff is not configured")
-  ).millis
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker the duration of exponential backoff is not configured")).millis
 
   lazy val breaker: CircuitBreaker = new CircuitBreaker(
     actorSystem.scheduler,
     breakerMaxFailures,
     breakerCallTimeout,
-    breakerResetTimeout
-  ).onHalfOpen {
+    breakerResetTimeout).onHalfOpen {
     circuitStatus.set(METRICS_BREAKER_OPEN)
   }.onOpen {
     circuitStatus.set(METRICS_BREAKER_OPEN)
@@ -81,14 +73,18 @@ class IAMClient @Inject() (
     circuitStatus.set(METRICS_BREAKER_CLOSED)
   }
 
+  implicit val retryRecover = retryFor { breakerMaxRetries } using {
+    exponentialBackoff { breakerRetryBackoff }
+  } monitorWith {
+    logger.logger onRetrying logNothing onInterrupted logWarning onAborted logError
+  }
+
   override def apply(token: OAuth2Token): Future[Option[TokenInfo]] = {
     breaker.withCircuitBreaker(
       plugableMetrics.timing(
         retryAsync(s"Calling $authEndpoint") {
           ws.url(authEndpoint).withQueryString(("access_token", token.value)).get()
-        }
-      )
-    ).map { response =>
+        })).map { response =>
         response.status match {
           case OK => Some(response.json.as[TokenInfo])
           case _ => None
@@ -98,12 +94,6 @@ class IAMClient @Inject() (
           logger.error(s"Exception occurred during validation of token '${token.toSafeString}': $e")
           None // consider any exception as invalid token
       }
-  }
-
-  implicit val retryRecover = retryFor { breakerMaxRetries } using {
-    exponentialBackoff { breakerRetryBackoff }
-  } monitorWith {
-    logger.logger onRetrying logNothing onInterrupted logWarning onAborted logError
   }
 
 }

--- a/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
+++ b/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
   */
 @Singleton
 class OAuth2AuthProvider @Inject() (getTokenInfo: (OAuth2Token) => Future[Option[TokenInfo]])
-    extends AuthProvider {
+  extends AuthProvider {
 
   val logger: Logger = Logger("security.OAuth2AuthProvider")
 

--- a/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
+++ b/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
@@ -3,15 +3,14 @@ package org.zalando.zhewbacca
 import javax.inject.{Inject, Singleton}
 
 import play.api.Logger
-import play.api.libs.concurrent.Execution.Implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Authorization provider which uses Zalando's IAM API to verify given OAuth2 token.
   */
 @Singleton
-class OAuth2AuthProvider @Inject() (getTokenInfo: (OAuth2Token) => Future[Option[TokenInfo]])
+class OAuth2AuthProvider @Inject() (getTokenInfo: (OAuth2Token) => Future[Option[TokenInfo]])(implicit ec: ExecutionContext)
   extends AuthProvider {
 
   val logger: Logger = Logger("security.OAuth2AuthProvider")

--- a/src/main/scala/org/zalando/zhewbacca/RequestValidator.scala
+++ b/src/main/scala/org/zalando/zhewbacca/RequestValidator.scala
@@ -1,17 +1,16 @@
 package org.zalando.zhewbacca
 
 import play.api.Logger
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 private[zhewbacca] object RequestValidator {
 
   val logger: Logger = Logger(this.getClass)
 
-  def validate[A](scope: Scope, requestHeader: RequestHeader, authProvider: AuthProvider): Future[Either[Result, TokenInfo]] = {
+  def validate[A](scope: Scope, requestHeader: RequestHeader, authProvider: AuthProvider)(implicit ec: ExecutionContext): Future[Either[Result, TokenInfo]] = {
     authProvider.valid(OAuth2Token.from(requestHeader), scope).map {
       case AuthTokenValid(tokenInfo) => Right(tokenInfo)
       case AuthTokenInvalid => Left(Results.Forbidden)

--- a/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
@@ -21,8 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecurityFilter @Inject() (
     rulesRepository: SecurityRulesRepository,
     implicit val mat: Materializer,
-    implicit val ec: ExecutionContext
-) extends Filter {
+    implicit val ec: ExecutionContext) extends Filter {
 
   override def apply(nextFilter: (RequestHeader) => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     rulesRepository.get(requestHeader).getOrElse {

--- a/src/main/scala/org/zalando/zhewbacca/SecurityRule.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityRule.scala
@@ -23,8 +23,7 @@ abstract class StrictRule(method: String, pathRegex: String) extends SecurityRul
 abstract case class ValidateTokenRule(
     method: String,
     pathRegex: String,
-    scope: Scope
-) extends StrictRule(method, pathRegex) {
+    scope: Scope) extends StrictRule(method, pathRegex) {
 
   def authProvider: AuthProvider
 

--- a/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
@@ -3,11 +3,11 @@ package org.zalando.zhewbacca
 import javax.inject.Inject
 
 import com.typesafe.config.{Config, ConfigFactory}
-import play.api.mvc.RequestHeader
 import play.api.{Configuration, Logger}
+import scala.collection.JavaConverters._
 
-import scala.collection.JavaConversions._
 import play.api.http.HttpVerbs._
+import play.api.mvc.RequestHeader
 
 class SecurityRulesRepository @Inject() (configuration: Configuration, provider: AuthProvider) {
 
@@ -25,12 +25,12 @@ class SecurityRulesRepository @Inject() (configuration: Configuration, provider:
     rules.find(_.isApplicableTo(requestHeader))
 
   private def load(): Seq[StrictRule] = {
-    val securityRulesFileName = configuration.getString("authorisation.rules.file").getOrElse("security_rules.conf")
+    val securityRulesFileName = configuration.getOptional[String]("authorisation.rules.file").getOrElse("security_rules.conf")
     Logger.info(s"Configuration file for security rules: $securityRulesFileName")
 
     if (configFileExists(securityRulesFileName)) {
       ConfigFactory.load(securityRulesFileName)
-        .getConfigList(ConfigKeyRules)
+        .getConfigList(ConfigKeyRules).asScala
         .map(toRule)
     } else {
       sys.error(s"configuration file $securityRulesFileName for security rules not found")
@@ -82,7 +82,7 @@ class SecurityRulesRepository @Inject() (configuration: Configuration, provider:
 
   private def getScopeNames(config: Config): Option[Set[String]] = {
     if (config.hasPath(ConfigKeyScopes)) {
-      Some(config.getStringList(ConfigKeyScopes).toSet)
+      Some(config.getStringList(ConfigKeyScopes).asScala.toSet)
     } else {
       None
     }

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
@@ -10,6 +10,5 @@ object TokenInfo {
     (JsPath \ "access_token").read[String] and
     (JsPath \ "scope").read[Seq[String]].map(names => Scope(Set(names: _*))) and
     (JsPath \ "token_type").read[String] and
-    (JsPath \ "uid").read[String]
-  )(TokenInfo.apply _)
+    (JsPath \ "uid").read[String])(TokenInfo.apply _)
 }

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
@@ -1,34 +1,35 @@
 package org.zalando.zhewbacca
 
+import play.api.libs.typedmap.TypedKey
 import play.api.mvc.RequestHeader
 
 object TokenInfoConverter {
 
+  private val AccessTokenKey: TypedKey[String] = TypedKey("tokenInfo.access_token")
+  private val ScopeKey: TypedKey[String] = TypedKey("tokenInfo.scope")
+  private val ScopeSeparator = '|'
+  private val TokenTypeKey: TypedKey[String] = TypedKey("tokenInfo.token_type")
+  private val UidKey: TypedKey[String] = TypedKey("tokenInfo.uid")
+
   implicit class AuthenticatedRequestHeader(underlying: RequestHeader) {
 
-    private val AccessTokenKey = "tokenInfo.access_token"
-    private val ScopeKey = "tokenInfo.scope"
-    private val ScopeSeparator = '|'
-    private val TokenTypeKey = "tokenInfo.token_type"
-    private val UidKey = "tokenInfo.uid"
-
     def tokenInfo: TokenInfo = {
-      val accessToken = underlying.tags.getOrElse(AccessTokenKey, sys.error("access token not provided"))
-      val scopeNames = underlying.tags.getOrElse(ScopeKey, sys.error("scope not provided"))
+      val accessToken = underlying.attrs.get(AccessTokenKey).getOrElse(sys.error("access token not provided"))
+      val scopeNames = underlying.attrs.get(ScopeKey).getOrElse(sys.error("scope not provided"))
         .split(ScopeSeparator)
         .toSet
-      val tokenType = underlying.tags.getOrElse(TokenTypeKey, sys.error("token type is not provided"))
-      val uid = underlying.tags.getOrElse(UidKey, sys.error("user id is not provided"))
+      val tokenType = underlying.attrs.get(TokenTypeKey).getOrElse(sys.error("token type is not provided"))
+      val uid = underlying.attrs.get(UidKey).getOrElse(sys.error("user id is not provided"))
 
       TokenInfo(accessToken, Scope(scopeNames), tokenType, uid)
     }
 
-    private[zhewbacca] def withTokenInfo(tokenInfo: TokenInfo): RequestHeader = {
+    private[zhewbacca] def withTokenInfo(tok: TokenInfo): RequestHeader = {
       underlying
-        .withTag(AccessTokenKey, tokenInfo.accessToken)
-        .withTag(ScopeKey, tokenInfo.scope.names.mkString(ScopeSeparator.toString))
-        .withTag(TokenTypeKey, tokenInfo.tokenType)
-        .withTag(UidKey, tokenInfo.userUid)
+        .addAttr(AccessTokenKey, tok.accessToken)
+        .addAttr(ScopeKey, tok.scope.names.mkString(ScopeSeparator.toString))
+        .addAttr(TokenTypeKey, tok.tokenType)
+        .addAttr(UidKey, tok.userUid)
     }
   }
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,23 @@
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+<configuration>
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{"yyyy-MM-dd HH:mm:ss,SSS"} {%level} [%.20thread] [%mdc{X-Flow-ID:--}] [%logger{40}] %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <root level="INFO">
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+
+</configuration>

--- a/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
@@ -6,7 +6,7 @@ import org.zalando.zhewbacca.metrics.NoOpPlugableMetrics
 import play.api.http.{DefaultFileMimeTypes, FileMimeTypesConfiguration, Port}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
-import play.api.mvc.{Action, Handler, Result, Results}
+import play.api.mvc._
 import play.api.test.WsTestClient
 import play.api.{Application, Configuration, Mode}
 import play.core.server.Server

--- a/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
@@ -1,7 +1,7 @@
 package org.zalando.zhewbacca
 
 import org.specs2.mutable.Specification
-
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
@@ -13,8 +13,7 @@ class OAuth2AuthProviderSpec extends Specification {
       val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenValid(tokenInfo))
     }
@@ -23,8 +22,7 @@ class OAuth2AuthProviderSpec extends Specification {
       val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid", "cn")), "Bearer", userUid = "1234")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenValid(tokenInfo))
     }
@@ -32,8 +30,7 @@ class OAuth2AuthProviderSpec extends Specification {
     "reject token when IAM reports it is not valid one" in {
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(None)).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
     }
@@ -42,8 +39,7 @@ class OAuth2AuthProviderSpec extends Specification {
       val tokenInfo = TokenInfo("986c2946-c754-4e58-a0cb-7e86e3e9901b", Scope(Set("uid")), "Bearer", userUid = "1234")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
     }
@@ -52,8 +48,7 @@ class OAuth2AuthProviderSpec extends Specification {
       val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid", "seo_description.write"))
-      )
+        Scope(Set("uid", "seo_description.write")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
     }
@@ -62,8 +57,7 @@ class OAuth2AuthProviderSpec extends Specification {
       val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Token", userUid = "1234")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
     }
@@ -71,8 +65,7 @@ class OAuth2AuthProviderSpec extends Specification {
     "reject empty token" in {
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(None)).valid(
         None,
-        Scope(Set("uid"))
-      )
+        Scope(Set("uid")))
 
       Await.result(request, 1.second) must beEqualTo(AuthTokenEmpty)
     }

--- a/src/test/scala/org/zalando/zhewbacca/OAuth2TokenSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/OAuth2TokenSpec.scala
@@ -15,8 +15,7 @@ class OAuth2TokenSpec extends Specification {
     "be extracted only from first 'Authorization' request header" in {
       val request = FakeRequest().withHeaders(
         "Authorization" -> "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
-        "Authorization" -> "Bearer 78d6c4c9-b777-4524-9c59-dbf55a3f8ad1"
-      )
+        "Authorization" -> "Bearer 78d6c4c9-b777-4524-9c59-dbf55a3f8ad1")
 
       OAuth2Token.from(request) must be equalTo None
     }

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -6,7 +6,7 @@ import play.api.test.FakeRequest
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-
+import scala.concurrent.ExecutionContext.Implicits.global
 class RequestValidatorSpec extends Specification {
 
   val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid")

--- a/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
@@ -30,8 +30,7 @@ class SecurityFilterSpec extends PlaySpecification with BodyParsers {
     .routes(routes)
     .configure(
       "play.http.filters" -> "org.zalando.zhewbacca.TestingFilters",
-      "authorisation.rules.file" -> "security_filter.conf"
-    )
+      "authorisation.rules.file" -> "security_filter.conf")
     .build
 
   "SecurityFilter" should {

--- a/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
@@ -2,10 +2,11 @@ package org.zalando.zhewbacca
 
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import play.api.http.Status.FORBIDDEN
+import play.api.libs.typedmap.TypedKey
 import play.api.mvc.{RequestHeader, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.http.Status.FORBIDDEN
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -59,9 +60,10 @@ class SecurityRuleSpec extends Specification with Mockito {
 
   "ExplicitlyAllowedRule" should {
     "pass unmodified request to next filter" in { implicit ec: ExecutionContext =>
-      val originalRequest = FakeRequest("GET", "/foo").withTag("testTag", "testValue")
+      val testAttribute: TypedKey[String] = TypedKey("testAttribute")
+      val originalRequest = FakeRequest("GET", "/foo").addAttr(testAttribute, "testValue")
       val rule = new ExplicitlyAllowedRule("GET", "/foo")
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok(request.tags("testTag"))) }
+      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok(request.attrs(testAttribute))) }
 
       contentAsString(rule.execute(nextFilter, originalRequest)) must beEqualTo("testValue")
     }


### PR DESCRIPTION
Fixes #35 

Upgrade to Play Framework 2.6.3 and Scala 2.12.3. Most of the deprecation warnings are fixed. See PR comments.