### PR TITLE
Use sbt 1.0, Play 2.6.6, changed github organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [0.3.2] - 2017-10-26
+### Changed
+- Use sbt 1.0 to build
+- Upgrade Play Framework to 2.6.6
+
 ## [0.3.1] - 2017-10-21
 ### Changed
 - Scala and Playframework versions has been upgraded by @matterche. Now the library requires Scala v2.12.3 and Playframework v2.6.3. Note that there might be an [issue with circuit breaker](https://github.com/zalando-incubator/play-zhewbacca/issues/43).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,18 +19,18 @@ To report a new bug you should open an issue that summarizes the bug and set the
 If you want to provide a fix along with your bug report: That is great! In this case please send us a pull request as described in section [Contribute Code](#contribute-code).
 
 ## Suggest a feature
-To request a new feature you should open an [issue](https://github.com/zalando-incubator/play-zhewbacca/issues/new) and summarize the desired functionality and its use case. Set the issue label to "feature".  
+To request a new feature you should open an [issue](https://github.com/zalando-stups/play-zhewbacca/issues/new) and summarize the desired functionality and its use case. Set the issue label to "feature".  
 
 ## Contribute code
 This is a rough outline of what the workflow for code contributions looks like:
-- Check the list of open [issues](https://github.com/zalando-incubator/play-zhewbacca/issues). Either assign an existing issue to yourself, or create a new one that you would like work on and discuss your ideas and use cases.
+- Check the list of open [issues](https://github.com/zalando-stups/play-zhewbacca/issues). Either assign an existing issue to yourself, or create a new one that you would like work on and discuss your ideas and use cases.
 - Fork the repository on GitHub
 - Create a topic branch from where you want to base your work. This is usually master.
 - Make commits of logical units.
 - Write good commit messages (see below).
 - Push your changes to a topic branch in your fork of the repository.
-- Submit a pull request to [zalando-incubator/play-zhewbacca](https://github.com/zalando-incubator/play-zhewbacca)
-- Your pull request must receive a :thumbsup: from two [Maintainers](https://github.com/zalando-incubator/play-zhewbacca/blob/master/MAINTAINERS)
+- Submit a pull request to [zalando-stups/play-zhewbacca](https://github.com/zalando-stups/play-zhewbacca)
+- Your pull request must receive a :thumbsup: from two [Maintainers](https://github.com/zalando-stups/play-zhewbacca/blob/master/MAINTAINERS)
 
 Thanks for your contributions!
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Play-security library
 
-![Build Status - Master](https://travis-ci.org/zalando-incubator/play-zhewbacca.svg?branch=master)
+![Build Status - Master](https://travis-ci.org/zalando-stups/play-zhewbacca.svg?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.zalando/play-zhewbacca_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.zalando/play-zhewbacca_2.11)
-[![codecov.io](https://codecov.io/github/zalando-incubator/play-zhewbacca/coverage.svg?branch=master)](https://codecov.io/github/zalando-incubator/play-zhewbacca?branch=master)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/fa1fb822bc1246508d343880c0b1868c)](https://www.codacy.com/app/dmitrykrivaltsevich/play-zhewbacca?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando-incubator/play-zhewbacca&amp;utm_campaign=Badge_Grade)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/zalando-incubator/play-zhewbacca/master/LICENSE)
+[![codecov.io](https://codecov.io/github/zalando-incubator/play-zhewbacca/coverage.svg?branch=master)](https://codecov.io/github/zalando-stups/play-zhewbacca?branch=master)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/fa1fb822bc1246508d343880c0b1868c)](https://www.codacy.com/app/dmitrykrivaltsevich/play-zhewbacca?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=zalando-stups/play-zhewbacca&amp;utm_campaign=Badge_Grade)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/zalando-stups/play-zhewbacca/master/LICENSE)
 
 
 **[Table of Contents](http://tableofcontent.eu)**
@@ -67,7 +67,7 @@ We mainly decided to release this library because we saw the needs of OAuth2 pro
 Configure libraries dependencies in your `build.sbt`:
 
 ```scala
-libraryDependencies += "org.zalando" %% "play-zhewbacca" % "0.2.2"
+libraryDependencies += "org.zalando" %% "play-zhewbacca" % "0.3.2"
 ```
 
 To configure Development environment:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scalariform.formatter.preferences._
 
 val commonSettings = Seq(
   organization := "org.zalando",
-  version := "0.3.1",
+  version := "0.3.2",
   scalaVersion := "2.12.3",
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
   publishTo := {
@@ -26,7 +26,7 @@ val commonSettings = Seq(
   )
 )
 
-val playFrameworkVersion = "2.6.5"
+val playFrameworkVersion = "2.6.6"
 
 lazy val testDependencies =
   Seq(
@@ -69,7 +69,7 @@ lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 
 compileScalastyle := scalastyle.in(Compile).toTask("").value
 
-(compileInputs in(Compile, compile)) <<= (compileInputs in(Compile, compile)) dependsOn compileScalastyle
+(compileInputs in(Compile, compile)) := ((compileInputs in(Compile, compile)) dependsOn compileScalastyle).value
 
 scalariformSettings(autoformat = true)
 
@@ -86,17 +86,17 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(SpacesAroundMultiImports, false)
 
 pomExtra := (
-  <url>https://github.com/zalando-incubator/play-zhewbacca</url>
+  <url>https://github.com/zalando-stups/play-zhewbacca</url>
     <licenses>
       <license>
         <name>MIT License</name>
-        <url>https://raw.githubusercontent.com/zalando-incubator/play-zhewbacca/master/LICENSE</url>
+        <url>https://raw.githubusercontent.com/zalando-stups/play-zhewbacca/master/LICENSE</url>
         <distribution>repo</distribution>
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:zalando-incubator/play-zhewbacca.git</url>
-      <connection>scm:git:git@github.com:zalando-incubator/play-zhewbacca.git</connection>
+      <url>git@github.com:zalando-stups/play-zhewbacca.git</url>
+      <connection>scm:git:git@github.com:zalando-stups/play-zhewbacca.git</connection>
     </scm>
     <developers>
       <developer>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.2


### PR DESCRIPTION
* Added build.properties to guarantee the same sbt version on every machine
* Use sbt 1.0.2 and migrate removed operators in build.sbt
* Use play 2.6.6 (supports sbt 1.0)
* Renamed github org zalando-incubator to zalando-stups where it was mentioned