### PR TITLE
Cross compile for scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val commonSettings = Seq(
   organization := "org.zalando",
   version := "0.3.2",
   scalaVersion := "2.12.3",
+  crossScalaVersions := Seq(scalaVersion.value, "2.11.11"),
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
Adding the necessary config to build.sbt to cross compile for scala 2.11

Please release with:

```
sbt +publish
```

https://www.scala-sbt.org/1.0/docs/Cross-Build.html

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>