### PR TITLE
Adjust response codes

### DIFF
--- a/src/main/scala/org/zalando/zhewbacca/AuthResult.scala
+++ b/src/main/scala/org/zalando/zhewbacca/AuthResult.scala
@@ -4,4 +4,5 @@ sealed abstract class AuthResult
 
 case object AuthTokenInvalid extends AuthResult
 case object AuthTokenEmpty extends AuthResult
+case object AuthTokenInsufficient extends AuthResult
 case class AuthTokenValid(tokenInfo: TokenInfo) extends AuthResult

--- a/src/main/scala/org/zalando/zhewbacca/RequestValidator.scala
+++ b/src/main/scala/org/zalando/zhewbacca/RequestValidator.scala
@@ -13,13 +13,14 @@ private[zhewbacca] object RequestValidator {
   def validate[A](scope: Scope, requestHeader: RequestHeader, authProvider: AuthProvider)(implicit ec: ExecutionContext): Future[Either[Result, TokenInfo]] = {
     authProvider.valid(OAuth2Token.from(requestHeader), scope).map {
       case AuthTokenValid(tokenInfo) => Right(tokenInfo)
-      case AuthTokenInvalid => Left(Results.Forbidden)
+      case AuthTokenInvalid => Left(Results.Unauthorized)
       case AuthTokenEmpty => Left(Results.Unauthorized)
+      case AuthTokenInsufficient => Left(Results.Forbidden)
     } recover {
       case NonFatal(e) =>
         logger.error(e.getMessage, e)
-        logger.debug("Request forbidden because of failure in Authentication Provider")
-        Left(Results.Forbidden)
+        logger.debug("Request unauthorized because of failure in Authentication Provider")
+        Left(Results.Unauthorized)
     }
   }
 }

--- a/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityFilter.scala
@@ -20,14 +20,13 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class SecurityFilter @Inject() (
     rulesRepository: SecurityRulesRepository,
-    provider: AuthProvider,
     implicit val mat: Materializer,
     implicit val ec: ExecutionContext) extends Filter {
 
   override def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     rulesRepository.get(requestHeader).getOrElse {
       Logger.debug(s"No security rules found for ${requestHeader.method} ${requestHeader.uri}. Access denied.")
-      DenyAllRule(provider)
+      DenyAllRule
     }.execute(nextFilter, requestHeader)
   }
 

--- a/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
@@ -45,7 +45,7 @@ class SecurityRulesRepository @Inject() (configuration: Configuration, provider:
 
       case (Some(method), pathRegex, Some(false), _) =>
         Logger.info(s"Explicitly denied all requests for method: '$method' and path regex: '$pathRegex'")
-        ExplicitlyDeniedRule(provider, method, pathRegex)
+        ExplicitlyDeniedRule(method, pathRegex)
 
       case (Some(method), pathRegex, None, Some(scopeNames)) =>
         Logger.info(s"Configured required scopes '$scopeNames' for method '$method' and path regex: '$pathRegex'")

--- a/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
+++ b/src/main/scala/org/zalando/zhewbacca/SecurityRulesRepository.scala
@@ -41,17 +41,15 @@ class SecurityRulesRepository @Inject() (configuration: Configuration, provider:
     (getHttpMethod(config), config.getString(ConfigKeyPathRegex), getAllowedFlag(config), getScopeNames(config)) match {
       case (Some(method), pathRegex, Some(true), _) =>
         Logger.info(s"Explicitly allowed unauthorized requests for method: '$method' and path regex: '$pathRegex'")
-        new ExplicitlyAllowedRule(method, pathRegex)
+        ExplicitlyAllowedRule(method, pathRegex)
 
       case (Some(method), pathRegex, Some(false), _) =>
         Logger.info(s"Explicitly denied all requests for method: '$method' and path regex: '$pathRegex'")
-        new ExplicitlyDeniedRule(method, pathRegex)
+        ExplicitlyDeniedRule(provider, method, pathRegex)
 
       case (Some(method), pathRegex, None, Some(scopeNames)) =>
         Logger.info(s"Configured required scopes '$scopeNames' for method '$method' and path regex: '$pathRegex'")
-        new ValidateTokenRule(method, pathRegex, Scope(scopeNames)) {
-          override val authProvider: AuthProvider = provider
-        }
+        ValidateTokenRule(provider, method, pathRegex, Scope(scopeNames))
 
       case _ =>
         sys.error(s"Invalid config: $config")

--- a/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
@@ -41,7 +41,7 @@ class OAuth2AuthProviderSpec extends Specification {
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))
 
-      Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
+      Await.result(request, 1.second) must beEqualTo(AuthTokenInsufficient)
     }
 
     "reject token with insufficient scopes" in {
@@ -50,7 +50,7 @@ class OAuth2AuthProviderSpec extends Specification {
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid", "seo_description.write")))
 
-      Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
+      Await.result(request, 1.second) must beEqualTo(AuthTokenInsufficient)
     }
 
     "reject non 'Bearer' token" in {
@@ -59,7 +59,7 @@ class OAuth2AuthProviderSpec extends Specification {
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))
 
-      Await.result(request, 1.second) must beEqualTo(AuthTokenInvalid)
+      Await.result(request, 1.second) must beEqualTo(AuthTokenInsufficient)
     }
 
     "reject empty token" in {

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -34,7 +34,7 @@ class RequestValidatorSpec extends Specification {
       result.left.get must beEqualTo(Results.Unauthorized)
     }
 
-    "return HTTP status 403 (forbidden) when token is in valid" in {
+    "return HTTP status 401 (unauthorized) when token is in valid" in {
       val authProvider = new AuthProvider {
         override def valid(token: Option[OAuth2Token], scope: Scope): Future[AuthResult] =
           Future.successful(AuthTokenInvalid)
@@ -42,13 +42,24 @@ class RequestValidatorSpec extends Specification {
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
       result.isLeft must beTrue
-      result.left.get must beEqualTo(Results.Forbidden)
+      result.left.get must beEqualTo(Results.Unauthorized)
     }
 
-    "return HTTP status 403 (forbidden) when Authorization provider has failed" in {
+    "return HTTP status 401 (unauthorized) when Authorization provider has failed" in {
       val authProvider = new AuthProvider {
         override def valid(token: Option[OAuth2Token], scope: Scope): Future[AuthResult] =
           Future.failed(new RuntimeException)
+      }
+
+      val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
+      result.isLeft must beTrue
+      result.left.get must beEqualTo(Results.Unauthorized)
+    }
+
+    "return HTTP status 403 (forbidden) in case insufficient scopes" in {
+      val authProvider = new AuthProvider {
+        override def valid(token: Option[OAuth2Token], scope: Scope): Future[AuthResult] =
+          Future.successful(AuthTokenInsufficient)
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)

--- a/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
@@ -72,22 +72,15 @@ class SecurityRuleSpec(implicit ec: ExecutionContext) extends Specification with
   "ExplicitlyDeniedRule" should {
 
     "be applicable to specific request" in {
-      val rule = ExplicitlyDeniedRule(authProvider(AuthTokenInvalid), "GET", "/foo.*")
+      val rule = ExplicitlyDeniedRule("GET", "/foo.*")
 
       rule.isApplicableTo(FakeRequest("GET", "/foo/bar")) must beTrue
       rule.isApplicableTo(FakeRequest("GET", "/bar/foo")) must beFalse
     }
 
-    "reject a request and respond with 401 HTTP status in case no token" in {
-      val rule = ExplicitlyDeniedRule(authProvider(AuthTokenEmpty), "GET", "/foo")
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok) }
-
-      status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(UNAUTHORIZED)
-    }
-
-    "reject a request and respond with 403 HTTP status in case valid token" in {
-      val rule = ExplicitlyDeniedRule(authProvider(AuthTokenValid(testTokenInfo)), "GET", "/foo")
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok) }
+    "reject a request and respond with 403 HTTP" in {
+      val rule = ExplicitlyDeniedRule("GET", "/foo")
+      val nextFilter = { _: RequestHeader => Future.successful(Results.Ok) }
 
       status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(FORBIDDEN)
     }
@@ -97,38 +90,16 @@ class SecurityRuleSpec(implicit ec: ExecutionContext) extends Specification with
   "DenyAllRule" should {
 
     "be applicable to all requests" in {
-      val rule = DenyAllRule(authProvider(AuthTokenInvalid))
+      val rule = DenyAllRule
       rule.isApplicableTo(FakeRequest()) must beTrue
     }
 
-    "reject a request and respond with 401 HTTP status in case empty token" in {
-      val rule = DenyAllRule(authProvider(AuthTokenEmpty))
+    "reject a request and respond with 403 HTTP status" in {
+      val rule = DenyAllRule
       val nextFilter = { _: RequestHeader => Future.successful(Results.Ok) }
 
-      status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(UNAUTHORIZED)
-    }
-
-    "reject a request and respond with 401 HTTP status in case token is invalid " in {
-      val rule = DenyAllRule(authProvider(AuthTokenInvalid))
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok) }
-
-      status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(UNAUTHORIZED)
-    }
-
-    "reject a request and respond with 403 HTTP status in case valid token " in {
-      val rule = DenyAllRule(authProvider(AuthTokenValid(testTokenInfo)))
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok) }
-
       status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(FORBIDDEN)
     }
-
-    "reject a request and respond with 403 HTTP status in case" in {
-      val rule = DenyAllRule(authProvider(AuthTokenInsufficient))
-      val nextFilter = { request: RequestHeader => Future.successful(Results.Ok) }
-
-      status(rule.execute(nextFilter, FakeRequest())) must beEqualTo(FORBIDDEN)
-    }
-
   }
 
 }

--- a/src/test/scala/org/zalando/zhewbacca/SecurityRulesRepositorySpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityRulesRepositorySpec.scala
@@ -14,9 +14,7 @@ class SecurityRulesRepositorySpec extends Specification with Mockito {
     "load rules from default file" in {
       val provider = mock[AuthProvider]
       val repository = new SecurityRulesRepository(Configuration(), provider)
-      val expectedRule = new ValidateTokenRule("GET", "/foo", Scope(Set("uid", "entity.read"))) {
-        override val authProvider: AuthProvider = provider
-      }
+      val expectedRule = ValidateTokenRule(provider, "GET", "/foo", Scope(Set("uid", "entity.read")))
 
       repository.get(FakeRequest("GET", "/foo")) must beSome(expectedRule)
     }
@@ -25,9 +23,7 @@ class SecurityRulesRepositorySpec extends Specification with Mockito {
       val provider = mock[AuthProvider]
       val config = Configuration("authorisation.rules.file" -> "security_custom-security.conf")
       val repository = new SecurityRulesRepository(config, provider)
-      val expectedRule = new ValidateTokenRule("POST", "/bar.*", Scope(Set("uid"))) {
-        override val authProvider: AuthProvider = provider
-      }
+      val expectedRule = ValidateTokenRule(provider, "POST", "/bar.*", Scope(Set("uid")))
 
       repository.get(FakeRequest("POST", "/bar.*")) must beSome(expectedRule)
     }
@@ -44,9 +40,7 @@ class SecurityRulesRepositorySpec extends Specification with Mockito {
       val provider = mock[AuthProvider]
       val config = Configuration("authorisation.rules.file" -> "security_commented.conf")
       val repository = new SecurityRulesRepository(config, provider)
-      val expectedRule = new ValidateTokenRule("OPTIONS", "/", Scope(Set("app.resource.read"))) {
-        override val authProvider: AuthProvider = provider
-      }
+      val expectedRule = ValidateTokenRule(provider, "OPTIONS", "/", Scope(Set("app.resource.read")))
 
       repository.get(FakeRequest("OPTIONS", "/")) must beSome(expectedRule)
     }


### PR DESCRIPTION
Resolves #53 

introduce new auth result: AuthTokenInsufficient
changed response codes for cases:
1) in case auth failure return 401 instead of 403
2) in case empty token or invalid token return 401 instead of 403
3) return 403 only in case there is token but without proper scopes

fix deny and denyAll rules:
1) return 401 for deny rule in case empty token | invalid token
2) return 403 in case token is validated

