### PR TITLE
add realm to tokeninfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ logs/
 *.sc
 *.swp
 
+.cache-main
+.cache-tests
+.classpath
+.project
+.settings/

--- a/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
+++ b/src/main/scala/org/zalando/zhewbacca/OAuth2AuthProvider.scala
@@ -25,9 +25,9 @@ class OAuth2AuthProvider @Inject() (getTokenInfo: (OAuth2Token) => Future[Option
 
   private def validateTokenInfo(tokenInfo: Option[TokenInfo], token: OAuth2Token, scope: Scope): AuthResult = {
     tokenInfo match {
-      case Some(tokenInfo @ TokenInfo(`token`.value, thatScope, `bearerTokenType`, _, _)) if scope.in(thatScope) =>
+      case Some(tokenInfo @ TokenInfo(`token`.value, thatScope, `bearerTokenType`, _, _, _)) if scope.in(thatScope) =>
         AuthTokenValid(tokenInfo)
-      case Some(tokenInfo @ TokenInfo(_, thatScope, tokenType, _, _)) =>
+      case Some(tokenInfo @ TokenInfo(_, thatScope, tokenType, _, _, _)) =>
         logger.info(s"Token '${token.toSafeString} has insufficient scope or wrong type, token scopes are ${thatScope.names.mkString(", ")}," +
           s"token type is $tokenType")
         AuthTokenInsufficient

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
@@ -3,7 +3,13 @@ package org.zalando.zhewbacca
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Reads}
 
-case class TokenInfo(accessToken: String, scope: Scope, tokenType: String, userUid: String, realm: String, clientId: Option[String] = None)
+case class TokenInfo(
+    accessToken: String,
+    scope: Scope,
+    tokenType: String,
+    userUid: String,
+    clientId: Option[String] = None,
+    realm: String = "unknown")
 
 object TokenInfo {
   implicit val tokenInfoReads: Reads[TokenInfo] = (
@@ -11,6 +17,6 @@ object TokenInfo {
     (JsPath \ "scope").read[Seq[String]].map(names => Scope(Set(names: _*))) and
     (JsPath \ "token_type").read[String] and
     (JsPath \ "uid").read[String] and
-    (JsPath \ "realm").read[String] and
-    (JsPath \ "client_id").readNullable[String])(TokenInfo.apply _)
+    (JsPath \ "client_id").readNullable[String] and
+    (JsPath \ "realm").read[String])(TokenInfo.apply _)
 }

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfo.scala
@@ -3,7 +3,7 @@ package org.zalando.zhewbacca
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Reads}
 
-case class TokenInfo(accessToken: String, scope: Scope, tokenType: String, userUid: String, clientId: Option[String] = None)
+case class TokenInfo(accessToken: String, scope: Scope, tokenType: String, userUid: String, realm: String, clientId: Option[String] = None)
 
 object TokenInfo {
   implicit val tokenInfoReads: Reads[TokenInfo] = (
@@ -11,5 +11,6 @@ object TokenInfo {
     (JsPath \ "scope").read[Seq[String]].map(names => Scope(Set(names: _*))) and
     (JsPath \ "token_type").read[String] and
     (JsPath \ "uid").read[String] and
+    (JsPath \ "realm").read[String] and
     (JsPath \ "client_id").readNullable[String])(TokenInfo.apply _)
 }

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
@@ -25,7 +25,7 @@ object TokenInfoConverter {
       val clientId = underlying.attrs.get(ClientIdKey).flatten
       val realm = underlying.attrs.get(RealmKey).getOrElse(sys.error("realm is not provided"))
 
-      TokenInfo(accessToken, Scope(scopeNames), tokenType, uid, realm, clientId)
+      TokenInfo(accessToken, Scope(scopeNames), tokenType, uid, clientId, realm)
     }
 
     private[zhewbacca] def withTokenInfo(tok: TokenInfo): RequestHeader = {

--- a/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
+++ b/src/main/scala/org/zalando/zhewbacca/TokenInfoConverter.scala
@@ -11,6 +11,7 @@ object TokenInfoConverter {
   private val TokenTypeKey: TypedKey[String] = TypedKey("tokenInfo.token_type")
   private val UidKey: TypedKey[String] = TypedKey("tokenInfo.uid")
   private val ClientIdKey: TypedKey[Option[String]] = TypedKey("tokenInfo.client_id")
+  private val RealmKey: TypedKey[String] = TypedKey("tokenInfo.realm")
 
   implicit class AuthenticatedRequestHeader(underlying: RequestHeader) {
 
@@ -22,8 +23,9 @@ object TokenInfoConverter {
       val tokenType = underlying.attrs.get(TokenTypeKey).getOrElse(sys.error("token type is not provided"))
       val uid = underlying.attrs.get(UidKey).getOrElse(sys.error("user id is not provided"))
       val clientId = underlying.attrs.get(ClientIdKey).flatten
+      val realm = underlying.attrs.get(RealmKey).getOrElse(sys.error("realm is not provided"))
 
-      TokenInfo(accessToken, Scope(scopeNames), tokenType, uid, clientId)
+      TokenInfo(accessToken, Scope(scopeNames), tokenType, uid, realm, clientId)
     }
 
     private[zhewbacca] def withTokenInfo(tok: TokenInfo): RequestHeader = {
@@ -33,6 +35,7 @@ object TokenInfoConverter {
         .addAttr(TokenTypeKey, tok.tokenType)
         .addAttr(UidKey, tok.userUid)
         .addAttr(ClientIdKey, tok.clientId)
+        .addAttr(RealmKey, tok.realm)
     }
   }
 

--- a/src/test/resources/valid-token-with-client-id.json
+++ b/src/test/resources/valid-token-with-client-id.json
@@ -5,5 +5,6 @@
   "token_type": "Bearer",
   "access_token": "311f3ab2-4116-45a0-8bb0-50c3bca0441d",
   "uid": "user uid",
+  "realm": "/employees",
   "client_id": "Kashyyyk"
 }

--- a/src/test/resources/valid-token-with-uid-scope.json
+++ b/src/test/resources/valid-token-with-uid-scope.json
@@ -4,5 +4,6 @@
   ],
   "token_type": "Bearer",
   "access_token": "311f3ab2-4116-45a0-8bb0-50c3bca0441d",
-  "uid": "user uid"
+  "uid": "user uid",
+  "realm": "/employees"
 }

--- a/src/test/resources/valid-token-with-unknown-field.json
+++ b/src/test/resources/valid-token-with-unknown-field.json
@@ -5,5 +5,6 @@
   "token_type": "Bearer",
   "access_token": "311f3ab2-4116-45a0-8bb0-50c3bca0441d",
   "uid": "user uid",
+  "realm": "/services",
   "new_and_shiny_field": true
 }

--- a/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
@@ -4,7 +4,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 
 class AlwaysPassAuthProviderSpec(implicit ee: ExecutionEnv) extends Specification {
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
 
   "'Always pass' Authorization Provider" should {
     "accept any tokens and scopes and treat them as valid" in {

--- a/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
@@ -4,15 +4,15 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 
 class AlwaysPassAuthProviderSpec(implicit ee: ExecutionEnv) extends Specification {
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
+  val testTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   "'Always pass' Authorization Provider" should {
     "accept any tokens and scopes and treat them as valid" in {
-      val authProvider = new AlwaysPassAuthProvider(TestTokenInfo)
+      val authProvider = new AlwaysPassAuthProvider(testTokenInfo)
       val scope = Scope(Set("any_scope"))
       val token = Some(OAuth2Token("6afe9886-0a0a-4ace-8bc7-fb96920fb764"))
 
-      authProvider.valid(token, scope) must beEqualTo(AuthTokenValid(TestTokenInfo)).await
+      authProvider.valid(token, scope) must beEqualTo(AuthTokenValid(testTokenInfo)).await
     }
   }
 

--- a/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/AlwaysPassAuthProviderSpec.scala
@@ -4,7 +4,7 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 
 class AlwaysPassAuthProviderSpec(implicit ee: ExecutionEnv) extends Specification {
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   "'Always pass' Authorization Provider" should {
     "accept any tokens and scopes and treat them as valid" in {

--- a/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
@@ -34,7 +34,8 @@ class IAMClientSpec extends Specification {
             "311f3ab2-4116-45a0-8bb0-50c3bca0441d",
             Scope(Set("uid")),
             "Bearer",
-            userUid = "user uid")))
+            userUid = "user uid",
+            realm = "/employees")))
 
         }
       }
@@ -53,6 +54,7 @@ class IAMClientSpec extends Specification {
             Scope(Set("uid")),
             "Bearer",
             userUid = "user uid",
+            realm = "/employees",
             clientId = Some("Kashyyyk"))))
 
         }
@@ -71,7 +73,8 @@ class IAMClientSpec extends Specification {
             "311f3ab2-4116-45a0-8bb0-50c3bca0441d",
             Scope(Set("uid")),
             "Bearer",
-            userUid = "user uid")))
+            userUid = "user uid",
+            realm = "/services")))
 
         }
       }

--- a/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/OAuth2AuthProviderSpec.scala
@@ -10,7 +10,7 @@ class OAuth2AuthProviderSpec extends Specification {
   "IAM Authorization Provider" should {
 
     "accept valid token with necessary scope" in {
-      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234")
+      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234", realm = "/employees")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))
@@ -19,7 +19,7 @@ class OAuth2AuthProviderSpec extends Specification {
     }
 
     "accept token which has many scopes" in {
-      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid", "cn")), "Bearer", userUid = "1234")
+      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid", "cn")), "Bearer", userUid = "1234", realm = "/employees")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))
@@ -36,7 +36,7 @@ class OAuth2AuthProviderSpec extends Specification {
     }
 
     "reject token if IAM responses with Token Info for different token" in {
-      val tokenInfo = TokenInfo("986c2946-c754-4e58-a0cb-7e86e3e9901b", Scope(Set("uid")), "Bearer", userUid = "1234")
+      val tokenInfo = TokenInfo("986c2946-c754-4e58-a0cb-7e86e3e9901b", Scope(Set("uid")), "Bearer", userUid = "1234", realm = "/employees")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))
@@ -45,7 +45,7 @@ class OAuth2AuthProviderSpec extends Specification {
     }
 
     "reject token with insufficient scopes" in {
-      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234")
+      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Bearer", userUid = "1234", realm = "/employees")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid", "seo_description.write")))
@@ -54,7 +54,7 @@ class OAuth2AuthProviderSpec extends Specification {
     }
 
     "reject non 'Bearer' token" in {
-      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Token", userUid = "1234")
+      val tokenInfo = TokenInfo("311f3ab2-4116-45a0-8bb0-50c3bca0441d", Scope(Set("uid")), "Token", userUid = "1234", realm = "/employees")
       val request = new OAuth2AuthProvider((token: OAuth2Token) => Future.successful(Some(tokenInfo))).valid(
         Some(OAuth2Token("311f3ab2-4116-45a0-8bb0-50c3bca0441d")),
         Scope(Set("uid")))

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -19,8 +19,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.isRight must beTrue
-      result.right.get must beEqualTo(testTokenInfo)
+      result.right must beEqualTo(Some(testTokenInfo))
     }
 
     "return HTTP status 401 (unauthorized) when token was not provided" in {
@@ -30,8 +29,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.isLeft must beTrue
-      result.left.get must beEqualTo(Results.Unauthorized)
+      result.left must beEqualTo(Some(Results.Unauthorized))
     }
 
     "return HTTP status 401 (unauthorized) when token is in valid" in {
@@ -41,8 +39,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.isLeft must beTrue
-      result.left.get must beEqualTo(Results.Unauthorized)
+      result.left must beEqualTo(Some(Results.Unauthorized))
     }
 
     "return HTTP status 401 (unauthorized) when Authorization provider has failed" in {
@@ -52,8 +49,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.isLeft must beTrue
-      result.left.get must beEqualTo(Results.Unauthorized)
+      result.left must beEqualTo(Some(Results.Unauthorized))
     }
 
     "return HTTP status 403 (forbidden) in case insufficient scopes" in {
@@ -63,8 +59,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.isLeft must beTrue
-      result.left.get must beEqualTo(Results.Forbidden)
+      result.left must beEqualTo(Some(Results.Forbidden))
     }
   }
 }

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 class RequestValidatorSpec extends Specification {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
 
   "Request Validator" should {
     "provide token information when token is valid" in {

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 class RequestValidatorSpec extends Specification {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   "Request Validator" should {
     "provide token information when token is valid" in {

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -19,7 +19,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.right must beEqualTo(Some(testTokenInfo))
+      result must beEqualTo(Right(testTokenInfo))
     }
 
     "return HTTP status 401 (unauthorized) when token was not provided" in {
@@ -29,7 +29,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.left must beEqualTo(Some(Results.Unauthorized))
+      result must beEqualTo(Left(Results.Unauthorized))
     }
 
     "return HTTP status 401 (unauthorized) when token is in valid" in {
@@ -39,7 +39,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.left must beEqualTo(Some(Results.Unauthorized))
+      result must beEqualTo(Left(Results.Unauthorized))
     }
 
     "return HTTP status 401 (unauthorized) when Authorization provider has failed" in {
@@ -49,7 +49,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.left must beEqualTo(Some(Results.Unauthorized))
+      result must beEqualTo(Left(Results.Unauthorized))
     }
 
     "return HTTP status 403 (forbidden) in case insufficient scopes" in {
@@ -59,7 +59,7 @@ class RequestValidatorSpec extends Specification {
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
-      result.left must beEqualTo(Some(Results.Forbidden))
+      result must beEqualTo(Left(Results.Forbidden))
     }
   }
 }

--- a/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/RequestValidatorSpec.scala
@@ -9,18 +9,18 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 class RequestValidatorSpec extends Specification {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
+  val testTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   "Request Validator" should {
     "provide token information when token is valid" in {
       val authProvider = new AuthProvider {
         override def valid(token: Option[OAuth2Token], scope: Scope): Future[AuthResult] =
-          Future.successful(AuthTokenValid(TestTokenInfo))
+          Future.successful(AuthTokenValid(testTokenInfo))
       }
 
       val result = Await.result(RequestValidator.validate(Scope(Set("uid")), FakeRequest(), authProvider), 1.seconds)
       result.isRight must beTrue
-      result.right.get must beEqualTo(TestTokenInfo)
+      result.right.get must beEqualTo(testTokenInfo)
     }
 
     "return HTTP status 401 (unauthorized) when token was not provided" in {

--- a/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
@@ -9,7 +9,7 @@ import play.api.{Application, Mode}
 
 class SecurityFilterSpec extends PlaySpecification with BodyParsers {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   val routes: PartialFunction[(String, String), Handler] = {
     // test action returning action type. Shows the usage and makes it possible to test basic behaviour

--- a/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
@@ -9,7 +9,7 @@ import play.api.{Application, Mode}
 
 class SecurityFilterSpec extends PlaySpecification with BodyParsers {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid")
+  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", "/employees")
 
   val routes: PartialFunction[(String, String), Handler] = {
     // test action returning action type. Shows the usage and makes it possible to test basic behaviour

--- a/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityFilterSpec.scala
@@ -9,7 +9,7 @@ import play.api.{Application, Mode}
 
 class SecurityFilterSpec extends PlaySpecification with BodyParsers {
 
-  val TestTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
+  val testTokenInfo = TokenInfo("", Scope.Empty, "token type", "user uid", realm = "/employees")
 
   val routes: PartialFunction[(String, String), Handler] = {
     // test action returning action type. Shows the usage and makes it possible to test basic behaviour
@@ -26,7 +26,7 @@ class SecurityFilterSpec extends PlaySpecification with BodyParsers {
 
   def appWithRoutes: Application = new GuiceApplicationBuilder()
     .in(Mode.Test)
-    .bindings(bind[AuthProvider] to new AlwaysPassAuthProvider(TestTokenInfo))
+    .bindings(bind[AuthProvider] to new AlwaysPassAuthProvider(testTokenInfo))
     .routes(routes)
     .configure(
       "play.http.filters" -> "org.zalando.zhewbacca.TestingFilters",
@@ -38,7 +38,7 @@ class SecurityFilterSpec extends PlaySpecification with BodyParsers {
     "allow protected inner action to access token info" in {
       val response = route(appWithRoutes, FakeRequest(GET, "/")).get
       status(response) must beEqualTo(OK)
-      contentAsString(response) must beEqualTo(TestTokenInfo.tokenType)
+      contentAsString(response) must beEqualTo(testTokenInfo.tokenType)
     }
 
     "deny an access when there is no security rule for the reguest is given" in {

--- a/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecurityRuleSpec(implicit ec: ExecutionContext) extends Specification with Mockito {
   sequential
 
-  private val testTokenInfo = TokenInfo("", Scope.Default, "token-type", "test-user-id")
+  private val testTokenInfo = TokenInfo("", Scope.Default, "token-type", "test-user-id", "/employees")
   private def authProvider(expectedResult: AuthResult): AuthProvider = {
     val provider = mock[AuthProvider]
     provider.valid(any[Option[OAuth2Token]], any[Scope]) returns Future.successful(expectedResult)

--- a/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/SecurityRuleSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecurityRuleSpec(implicit ec: ExecutionContext) extends Specification with Mockito {
   sequential
 
-  private val testTokenInfo = TokenInfo("", Scope.Default, "token-type", "test-user-id", "/employees")
+  private val testTokenInfo = TokenInfo("", Scope.Default, "token-type", "test-user-id", realm = "/employees")
   private def authProvider(expectedResult: AuthResult): AuthProvider = {
     val provider = mock[AuthProvider]
     provider.valid(any[Option[OAuth2Token]], any[Scope]) returns Future.successful(expectedResult)

--- a/src/test/scala/org/zalando/zhewbacca/TokenInfoConverterSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/TokenInfoConverterSpec.scala
@@ -9,7 +9,7 @@ class TokenInfoConverterSpec extends Specification {
     "extract TokenInfo from request metadata" in {
       import org.zalando.zhewbacca.TokenInfoConverter._
 
-      val tokenInfo = TokenInfo("12345", Scope(Set("uid", "entity.write", "entity.read")), "Bearer", "test-user-uid")
+      val tokenInfo = TokenInfo("12345", Scope(Set("uid", "entity.write", "entity.read")), "Bearer", "test-user-uid", realm = "/employees")
       val request = FakeRequest().withTokenInfo(tokenInfo)
 
       request.tokenInfo must beEqualTo(tokenInfo)


### PR DESCRIPTION
This allows controllers to extract the realm and do specific logic based on that.
In the future, it might also be possible to use this in rules.

As I don't yet understand how the rules work, I didn't try to add anything to the rules stuff.

Fixes #57.