### PR TITLE
Fixes #12: Use `FiniteDuration` in configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,17 @@ authorisation.iam.endpoint = "https://info.services.auth.example.com/oauth2/toke
 # Maximum number of failures before opening the circuit
 authorisation.iam.cb.maxFailures = 4
 
-# Duration in milliseconds after which to consider a call a failure
-authorisation.iam.cb.callTimeout = 2000
+# Duration after which to consider a call a failure
+authorisation.iam.cb.callTimeout = "2 sec"
 
-# Duration in milliseconds after which to attempt to close the circuit
-authorisation.iam.cb.resetTimeout = 60000
+# Duration after which to attempt to close the circuit
+authorisation.iam.cb.resetTimeout = "60 sec"
 
 # Maximum number of retries
 authorisation.iam.maxRetries = 3
 
 # Duration in milliseconds of the exponential backoff
-authorisation.iam.retry.backoff.duration = 100
+authorisation.iam.retry.backoff.duration = "100 ms"
 
 # IAMClient depends on Play internal WS client so it also has to be configured.
 # The maximum time to wait when connecting to the remote host.

--- a/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
+++ b/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
@@ -31,7 +31,7 @@ class IAMClient @Inject() (
     plugableMetrics: PlugableMetrics,
     ws: WSClient,
     actorSystem: ActorSystem,
-    implicit val ec: ExecutionContext) extends ((OAuth2Token) => Future[Option[TokenInfo]]) {
+    implicit val ec: ExecutionContext) extends (OAuth2Token => Future[Option[TokenInfo]]) {
 
   val logger: Logger = Logger("security.IAMClient")
 
@@ -43,23 +43,23 @@ class IAMClient @Inject() (
     circuitStatus.get
   }
 
-  val authEndpoint = config.getOptional[String]("authorisation.iam.endpoint").getOrElse(
+  val authEndpoint: String = config.getOptional[String]("authorisation.iam.endpoint").getOrElse(
     throw new IllegalArgumentException("Authorisation: IAM endpoint is not configured"))
 
-  val breakerMaxFailures = config.getOptional[Int]("authorisation.iam.cb.maxFailures").getOrElse(
+  val breakerMaxFailures: Int = config.getOptional[Int]("authorisation.iam.cb.maxFailures").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker max failures is not configured"))
 
-  val breakerCallTimeout = config.getOptional[Int]("authorisation.iam.cb.callTimeout").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker call timeout is not configured")).millis
+  val breakerCallTimeout: FiniteDuration = config.getOptional[FiniteDuration]("authorisation.iam.cb.callTimeout").getOrElse(
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker call timeout is not configured"))
 
-  val breakerResetTimeout = config.getOptional[Int]("authorisation.iam.cb.resetTimeout").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker reset timeout is not configured")).millis
+  val breakerResetTimeout: FiniteDuration = config.getOptional[FiniteDuration]("authorisation.iam.cb.resetTimeout").getOrElse(
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker reset timeout is not configured"))
 
-  val breakerMaxRetries = config.getOptional[Int]("authorisation.iam.maxRetries").getOrElse(
+  val breakerMaxRetries: TerminationPolicy = config.getOptional[Int]("authorisation.iam.maxRetries").getOrElse(
     throw new IllegalArgumentException("Authorisation: Circuit Breaker max retries is not configured")).attempts
 
-  val breakerRetryBackoff = config.getOptional[Int]("authorisation.iam.retry.backoff.duration").getOrElse(
-    throw new IllegalArgumentException("Authorisation: Circuit Breaker the duration of exponential backoff is not configured")).millis
+  val breakerRetryBackoff: FiniteDuration = config.getOptional[FiniteDuration]("authorisation.iam.retry.backoff.duration").getOrElse(
+    throw new IllegalArgumentException("Authorisation: Circuit Breaker the duration of exponential backoff is not configured"))
 
   lazy val breaker: CircuitBreaker = new CircuitBreaker(
     actorSystem.scheduler,


### PR DESCRIPTION
Fixes #12 Use `FiniteDuration` in configuration.

* Read `FiniteDuration` from configuration instead of `Int`. Old style will fallback to milliseconds automatically.
* Update `README` example with proper configuration values.