### PR TITLE
Fixes #11 Rename `Plugable*` to `Pluggable*` and update changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+## [Unreleased]
+### Changed
+- Rename `PlugableMetrics` trait to `PluggableMetrics`. Rename all occurrences of `Plugable*` to `Pluggable*`.
+- Add `Duration` support in configuration properties.
 
 ## [0.3.4] - 2018-06-06
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ package modules
 
 import com.google.inject.AbstractModule
 import org.zalando.zhewbacca._
-import org.zalando.zhewbacca.metrics.{NoOpPlugableMetrics, PlugableMetrics}
+import org.zalando.zhewbacca.metrics.{NoOpPluggableMetrics, PluggableMetrics}
 
 class DevModule extends AbstractModule {
   val TestTokenInfo = TokenInfo("", Scope.Default, "token type", "user uid")
   
   override def configure(): Unit = {
-    bind(classOf[PlugableMetrics]).to(classOf[NoOpPlugableMetrics])
+    bind(classOf[PluggableMetrics]).to(classOf[NoOpPluggableMetrics])
     bind(classOf[AuthProvider]).toInstance(new AlwaysPassAuthProvider(TestTokenInfo))
   }
   
@@ -97,7 +97,7 @@ package modules
 
 import com.google.inject.{ TypeLiteral, AbstractModule }
 import org.zalando.zhewbacca._
-import org.zalando.zhewbacca.metrics.{NoOpPlugableMetrics, PlugableMetrics}
+import org.zalando.zhewbacca.metrics.{NoOpPluggableMetrics, PluggableMetrics}
 
 import scala.concurrent.Future
 
@@ -105,14 +105,14 @@ class ProdModule extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[AuthProvider]).to(classOf[OAuth2AuthProvider])
-    bind(classOf[PlugableMetrics]).to(classOf[NoOpPlugableMetrics])
+    bind(classOf[PluggableMetrics]).to(classOf[NoOpPluggableMetrics])
     bind(new TypeLiteral[(OAuth2Token) => Future[Option[TokenInfo]]]() {}).to(classOf[IAMClient])
   }
 
 }
 ```
 
-By default no metrics mechanism is used. User can implement ```PlugableMetrics``` to gather some simple metrics.
+By default no metrics mechanism is used. User can implement ```PluggableMetrics``` to gather some simple metrics.
 See ```org.zalando.zhewbacca.IAMClient``` to learn what can be measured.
 
 You need to include `org.zalando.zhewbacca.SecurityFilter` into your applications' filters:

--- a/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
+++ b/src/main/scala/org/zalando/zhewbacca/IAMClient.scala
@@ -5,7 +5,7 @@ import javax.inject.{Inject, Singleton}
 
 import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
-import org.zalando.zhewbacca.metrics.PlugableMetrics
+import org.zalando.zhewbacca.metrics.PluggableMetrics
 import play.api.http.Status._
 import play.api.libs.ws.WSClient
 import play.api.{Configuration, Logger}
@@ -28,7 +28,7 @@ import atmos.dsl.Slf4jSupport._
 @Singleton
 class IAMClient @Inject() (
     config: Configuration,
-    plugableMetrics: PlugableMetrics,
+    pluggableMetrics: PluggableMetrics,
     ws: WSClient,
     actorSystem: ActorSystem,
     implicit val ec: ExecutionContext) extends (OAuth2Token => Future[Option[TokenInfo]]) {
@@ -39,7 +39,7 @@ class IAMClient @Inject() (
   val METRICS_BREAKER_OPEN = 1
   val circuitStatus = new AtomicInteger()
 
-  plugableMetrics.gauge {
+  pluggableMetrics.gauge {
     circuitStatus.get
   }
 
@@ -81,7 +81,7 @@ class IAMClient @Inject() (
 
   override def apply(token: OAuth2Token): Future[Option[TokenInfo]] = {
     breaker.withCircuitBreaker(
-      plugableMetrics.timing(
+      pluggableMetrics.timing(
         retryAsync(s"Calling $authEndpoint") {
           ws.url(authEndpoint).withQueryStringParameters(("access_token", token.value)).get()
         })).map { response =>

--- a/src/main/scala/org/zalando/zhewbacca/metrics/NoOpPluggableMetrics.scala
+++ b/src/main/scala/org/zalando/zhewbacca/metrics/NoOpPluggableMetrics.scala
@@ -2,7 +2,7 @@ package org.zalando.zhewbacca.metrics
 
 import scala.concurrent.Future
 
-class NoOpPlugableMetrics extends PlugableMetrics {
+class NoOpPluggableMetrics extends PluggableMetrics {
   override def timing[A](a: Future[A]): Future[A] = a
 
   override def gauge[A](f: => A): Unit = ()

--- a/src/main/scala/org/zalando/zhewbacca/metrics/PluggableMetrics.scala
+++ b/src/main/scala/org/zalando/zhewbacca/metrics/PluggableMetrics.scala
@@ -2,7 +2,7 @@ package org.zalando.zhewbacca.metrics
 
 import scala.concurrent.Future
 
-trait PlugableMetrics {
+trait PluggableMetrics {
   def timing[A](a: Future[A]): Future[A]
   def gauge[A](f: => A): Unit
 }

--- a/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
+++ b/src/test/scala/org/zalando/zhewbacca/IAMClientSpec.scala
@@ -2,7 +2,7 @@ package org.zalando.zhewbacca
 
 import akka.actor.ActorSystem
 import org.specs2.mutable.Specification
-import org.zalando.zhewbacca.metrics.NoOpPlugableMetrics
+import org.zalando.zhewbacca.metrics.NoOpPluggableMetrics
 import play.api.http.{DefaultFileMimeTypes, FileMimeTypesConfiguration, Port}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
@@ -207,6 +207,6 @@ class IAMClientSpec extends Specification {
       // generate new name each time so different registries are used
       "metrics.name" -> java.util.UUID.randomUUID.toString))
 
-    new IAMClient(clientConfig, new NoOpPlugableMetrics, client, actorSystem, ExecutionContext.Implicits.global)
+    new IAMClient(clientConfig, new NoOpPluggableMetrics, client, actorSystem, ExecutionContext.Implicits.global)
   }
 }


### PR DESCRIPTION
Fixes #11.
* Rename `Plugable*` to `Pluggable*` occurrences in code and documentation.
* Update `CHANGELOG` with information about renaming and `Duration` support in configuration.