### PR TITLE
#64 updated: play framework version changed from 2.7.0 to 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## [2.7.1] - 2019-05-19
+### Changed
+- Support of Play! 2.7.1
+
 ## [2.7.0] - 2019-03-28
 ### Changed
 - Rename `PlugableMetrics` trait to `PluggableMetrics`. Rename all occurrences of `Plugable*` to `Pluggable*`.

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 import scalariform.formatter.preferences._
 
-val playFrameworkVersion = "2.7.0"
+val playFrameworkVersion = "2.7.1"
 
 val commonSettings = Seq(
   organization := "org.zalando",
@@ -40,7 +40,7 @@ lazy val testDependencies =
 lazy val playDependencies =
   Seq(
     "com.typesafe.play" %% "play-ahc-ws" % playFrameworkVersion,
-    "com.typesafe.play" %% "play-json" % "2.6.9",
+    "com.typesafe.play" %% "play-json" % playFrameworkVersion,
     "com.typesafe.play" %% "play-ws" % playFrameworkVersion,
     "com.typesafe.play" %% "play" % playFrameworkVersion,
     "com.typesafe.play" %% "play-test" % playFrameworkVersion % "test",


### PR DESCRIPTION
Resolves #64 

Changes proposed in this PR:
- updated: play-json version changed from 2.6.9 to 2.7.1
- updated: target Play! version now is 2.7.1